### PR TITLE
Set supported TYPO3 version to v11.1.x only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ YubiKey two-factor MFA authentication for TYPO3
 
 ## What is it?
 
-A MFA provider for TYPO3 11.2+ which implements YubiKey OTP authentication
+A MFA provider for TYPO3 11.1+ which implements YubiKey OTP authentication
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
   "require": {
     "php": "^7.4",
     "ext-curl": "*",
-    "typo3/cms-core": "^11.2 || dev-master"
+    "typo3/cms-core": "~11.1.0 || dev-master"
   },
   "require-dev": {
-    "typo3/cms-backend": "^11.2 || dev-master",
-    "typo3/cms-frontend": "^11.2 || dev-master",
-    "typo3/cms-recordlist": "^11.2 || dev-master",
-    "typo3/cms-extbase": "^11.2 || dev-master",
-    "typo3/cms-fluid": "^11.2 || dev-master",
+    "typo3/cms-backend": "~11.1.0 || dev-master",
+    "typo3/cms-frontend": "~11.1.0 || dev-master",
+    "typo3/cms-recordlist": "~11.1.0 || dev-master",
+    "typo3/cms-extbase": "~11.1.0 || dev-master",
+    "typo3/cms-fluid": "~11.1.0 || dev-master",
     "typo3/testing-framework": "^6.6.2",
     "overtrue/phplint": "^1.1",
     "friendsofphp/php-cs-fixer": "^2.16.1"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.2.0-11.99.99',
+            'typo3' => '11.1.0-11.1.99',
             'php' => '7.4.0-7.4.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
The MFA API is still internal, therefore (breaking) changes
are to be expected in coming core releases